### PR TITLE
Add basic server test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ This repository contains a simple single-page application for tracking calories 
 3. Open `http://YOUR_SERVER_IP:3000` in a browser (or the port specified in the `PORT` environment variable)
 
 The `server.js` script serves the static `index.html` so you can deploy the repository on a VPS without any additional build steps.
+
+## Docker
+
+You can also run the site using Docker. Build and start the container with:
+
+```bash
+./docker_run.sh
+```
+
+The script builds the Docker image and runs it, exposing the port specified in the `PORT` environment variable (defaults to `3000`).
+
+## Testing
+
+Run `npm test` to start the server and verify the home page responds correctly.
+

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+IMAGE_NAME="claude-calories-tracker"
+PORT="${PORT:-3000}"
+
+# Build the Docker image
+docker build -t "$IMAGE_NAME" .
+
+# Run the container mapping the chosen port
+exec docker run --rm -p "$PORT:$PORT" -e PORT="$PORT" "$IMAGE_NAME"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a simple single-page application for tracking calories via voice input. It is implemented in plain HTML and React using CDN links so it can be hosted with GitHub Pages.",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/test.js
+++ b/test.js
@@ -1,0 +1,43 @@
+const { spawn } = require('child_process');
+const http = require('http');
+const assert = require('assert');
+
+const PORT = 3100;
+
+const serverProcess = spawn('node', ['server.js'], {
+  env: { ...process.env, PORT },
+  stdio: 'inherit'
+});
+
+function killServer() {
+  if (!serverProcess.killed) {
+    serverProcess.kill();
+  }
+}
+
+process.on('exit', killServer);
+process.on('SIGINT', () => { killServer(); process.exit(1); });
+
+// wait briefly for server to start
+setTimeout(() => {
+  http.get(`http://localhost:${PORT}`, res => {
+    let body = '';
+    res.on('data', chunk => body += chunk);
+    res.on('end', () => {
+      try {
+        assert.strictEqual(res.statusCode, 200, 'status code should be 200');
+        assert.ok(body.includes('<title>Voice Calorie Tracker</title>'), 'body should contain title');
+        console.log('Test passed');
+        killServer();
+      } catch (err) {
+        console.error('Test failed:', err.message);
+        killServer();
+        process.exitCode = 1;
+      }
+    });
+  }).on('error', err => {
+    console.error('Request failed:', err.message);
+    killServer();
+    process.exitCode = 1;
+  });
+}, 1000);


### PR DESCRIPTION
## Summary
- add simple Node-based integration test to verify the homepage responds
- wire up `npm test` to run the new script
- document the test command in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf1e18bdc8331856a9d9c72fec89e