### PR TITLE
Add update flag to deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ You can also run the site using Docker. Build and start the container with:
 ```
 
 The script builds the Docker image and runs it, exposing the port specified in the `PORT` environment variable (defaults to `3000`).
+Pass the `--update` flag to pull the latest changes before rebuilding. You can optionally provide the branch name (defaults to `main`):
+
+```bash
+./docker_run.sh --update [branch]
+```
 
 ## Testing
 

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -3,6 +3,30 @@ set -e
 
 IMAGE_NAME="claude-calories-tracker"
 PORT="${PORT:-3000}"
+UPDATE=false
+BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -u|--update)
+      UPDATE=true
+      if [[ -n "$2" && "$2" != -* ]]; then
+        BRANCH="$2"
+        shift 2
+      else
+        shift
+      fi
+      ;;
+    *)
+      echo "Usage: $0 [--update [branch]]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if $UPDATE; then
+  git pull origin "$BRANCH"
+fi
 
 # Build the Docker image
 docker build -t "$IMAGE_NAME" .


### PR DESCRIPTION
## Summary
- add `--update` flag to `docker_run.sh` to pull from main before deploying
- document update flag in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685cf5caa0d483319f509aef19cfc7bb