### PR TITLE
Stop old Docker container in deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can also run the site using Docker. Build and start the container with:
 ```
 
 The script builds the Docker image and runs it, exposing the port specified in the `PORT` environment variable (defaults to `3000`).
+If a container from a previous run is still active, the script will stop it before starting the new one to prevent port conflicts.
 Pass the `--update` flag to pull the latest changes before rebuilding. You can optionally provide the branch name (defaults to `main`):
 
 ```bash

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -2,6 +2,7 @@
 set -e
 
 IMAGE_NAME="claude-calories-tracker"
+CONTAINER_NAME="claude-calories-tracker"
 PORT="${PORT:-3000}"
 UPDATE=false
 BRANCH="main"
@@ -28,8 +29,15 @@ if $UPDATE; then
   git pull origin "$BRANCH"
 fi
 
+# Stop any previously running container
+RUNNING=$(docker ps -q -f name="^/${CONTAINER_NAME}$")
+if [[ -n "$RUNNING" ]]; then
+  echo "Stopping running container $CONTAINER_NAME..."
+  docker stop "$CONTAINER_NAME"
+fi
+
 # Build the Docker image
 docker build -t "$IMAGE_NAME" .
 
 # Run the container mapping the chosen port
-exec docker run --rm -p "$PORT:$PORT" -e PORT="$PORT" "$IMAGE_NAME"
+exec docker run --rm --name "$CONTAINER_NAME" -p "$PORT:$PORT" -e PORT="$PORT" "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- update deploy script to stop any running container before starting a new one
- document the new behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cf826a00083319fc05d63a2945415